### PR TITLE
Unified behavior to avoid line breaks at end of single-line input; fixed display corruption on Ctrl-D (EOF)

### DIFF
--- a/main.go
+++ b/main.go
@@ -746,9 +746,6 @@ func (m *Editor) init() error {
 	m.viewHeight -= m.StatusLineHeight
 
 	m.LineEditor.LineFeedWriter = func(rc readline.Result, w io.Writer) (int, error) {
-		if rc != readline.ENTER {
-			return fmt.Fprintln(w)
-		}
 		return 0, nil
 	}
 	if m.prompt == nil {


### PR DESCRIPTION
For #8