### PR TITLE
Follow upstream updates (go-box v3, go-readline-ny v1.12.1) and clean up dependencies

### DIFF
--- a/completion/main.go
+++ b/completion/main.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/nyaosorg/go-box/v2"
+	"github.com/nyaosorg/go-box/v3"
 	"github.com/nyaosorg/go-readline-ny"
 	singleCompletion "github.com/nyaosorg/go-readline-ny/completion"
 
@@ -109,7 +109,7 @@ func (C *CmdCompletionOrList) Call(ctx context.Context, B *readline.Buffer) read
 	m.SetNextEditHook(func(line string) bool {
 		m.GotoEndLine()
 
-		box.Print(ctx, list, B.Out)
+		box.Println(list, B.Out)
 
 		lfCount := m.PrintFromLine(m.Headline())
 		lfCount -= (m.CursorLine() - m.Headline())

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/atotto/clipboard v0.1.4
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-runewidth v0.0.19
-	github.com/nyaosorg/go-readline-ny v1.12.0
 	github.com/nyaosorg/go-box/v3 v3.0.0
+	github.com/nyaosorg/go-readline-ny v1.12.1
 	github.com/nyaosorg/go-ttyadapter v0.0.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -8,13 +8,13 @@ require (
 	github.com/mattn/go-runewidth v0.0.19
 	github.com/nyaosorg/go-box/v2 v2.2.1
 	github.com/nyaosorg/go-readline-ny v1.12.0
+	github.com/nyaosorg/go-ttyadapter v0.0.1
 )
 
 require (
 	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-tty v0.0.7 // indirect
-	github.com/nyaosorg/go-ttyadapter v0.0.1 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/atotto/clipboard v0.1.4
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-runewidth v0.0.19
-	github.com/nyaosorg/go-box/v2 v2.2.1
 	github.com/nyaosorg/go-readline-ny v1.12.0
+	github.com/nyaosorg/go-box/v3 v3.0.0
 	github.com/nyaosorg/go-ttyadapter v0.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,10 +10,10 @@ github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byF
 github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/mattn/go-tty v0.0.7 h1:KJ486B6qI8+wBO7kQxYgmmEFDaFEE96JMBQ7h400N8Q=
 github.com/mattn/go-tty v0.0.7/go.mod h1:f2i5ZOvXBU/tCABmLmOfzLz9azMo5wdAaElRNnJKr+k=
-github.com/nyaosorg/go-readline-ny v1.12.0 h1:0BzAosA9A2KGac8ywtGJUc1QZdsXrI6q975v10FDmc4=
-github.com/nyaosorg/go-readline-ny v1.12.0/go.mod h1:r0Gl9zAzS7UCTGwkmdRKu8htDHkqHq3IhAuv06l77DM=
 github.com/nyaosorg/go-box/v3 v3.0.0 h1:W5qfScEkKBoD68gbP/lwfWlvcTRB0rwXkhL+9iC62xI=
 github.com/nyaosorg/go-box/v3 v3.0.0/go.mod h1:70GsE9mIh7JKVCxt71q3jEijO6C9YJmOZqWpPa9w+GY=
+github.com/nyaosorg/go-readline-ny v1.12.1 h1:yEDbW3Np7a/mCKwww3cTQYc9c7U6OnPogMeAjXYUg5M=
+github.com/nyaosorg/go-readline-ny v1.12.1/go.mod h1:JgZg/fWrTrLe+0Pzc7LzptNK28YO6wrdVQPSmJF69ug=
 github.com/nyaosorg/go-ttyadapter v0.0.1 h1:4VslnofOrGLqXvVeKwz51BDR+Q82D2Iitk51urYRLGo=
 github.com/nyaosorg/go-ttyadapter v0.0.1/go.mod h1:w6ySb/Y8rpr0uIju4vN/TMRHC/6ayabORHmEVs6d/qE=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -10,10 +10,10 @@ github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byF
 github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/mattn/go-tty v0.0.7 h1:KJ486B6qI8+wBO7kQxYgmmEFDaFEE96JMBQ7h400N8Q=
 github.com/mattn/go-tty v0.0.7/go.mod h1:f2i5ZOvXBU/tCABmLmOfzLz9azMo5wdAaElRNnJKr+k=
-github.com/nyaosorg/go-box/v2 v2.2.1 h1:1SAtgLE+uYCA8oycJGKFrzsYaOWmxXWiqH8PR9wvnIo=
-github.com/nyaosorg/go-box/v2 v2.2.1/go.mod h1:IAW2+ri9apF0QTlZ5r5lkU+Rfnsigkmt6yODV7JMZ5E=
 github.com/nyaosorg/go-readline-ny v1.12.0 h1:0BzAosA9A2KGac8ywtGJUc1QZdsXrI6q975v10FDmc4=
 github.com/nyaosorg/go-readline-ny v1.12.0/go.mod h1:r0Gl9zAzS7UCTGwkmdRKu8htDHkqHq3IhAuv06l77DM=
+github.com/nyaosorg/go-box/v3 v3.0.0 h1:W5qfScEkKBoD68gbP/lwfWlvcTRB0rwXkhL+9iC62xI=
+github.com/nyaosorg/go-box/v3 v3.0.0/go.mod h1:70GsE9mIh7JKVCxt71q3jEijO6C9YJmOZqWpPa9w+GY=
 github.com/nyaosorg/go-ttyadapter v0.0.1 h1:4VslnofOrGLqXvVeKwz51BDR+Q82D2Iitk51urYRLGo=
 github.com/nyaosorg/go-ttyadapter v0.0.1/go.mod h1:w6ySb/Y8rpr0uIju4vN/TMRHC/6ayabORHmEVs6d/qE=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/main_test.go
+++ b/main_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nyaosorg/go-ttyadapter/auto"
 	"github.com/nyaosorg/go-readline-ny/keys"
+	"github.com/nyaosorg/go-ttyadapter/auto"
 )
 
 func TestEditorRead(t *testing.T) {

--- a/release_note_en.md
+++ b/release_note_en.md
@@ -1,3 +1,6 @@
+- Updated nyaosorg/go-box to v3.0.0 and adapted to the API changes in go-box v3
+- Updated nyaosorg/go-readline-ny to v1.12.1
+
 v0.22.0
 =======
 Nov 1, 2025

--- a/release_note_ja.md
+++ b/release_note_ja.md
@@ -1,3 +1,6 @@
+- nyaosorg/go-box を v3 へ更新し、API の変更に対応
+- nyaosorg/go-readline-ny を v1.12.1 へ更新
+
 v0.22.0
 =======
 Nov 1, 2025


### PR DESCRIPTION
## Changes in this pull request (English)

- Updated `nyaosorg/go-box` to v3.0.0 and adapted to its API changes
- Updated `nyaosorg/go-readline-ny` to v1.12.1
- Ran `go mod tidy` to reflect updated dependencies
- Applied `go fmt` to the modified files

## Changes in this pull request (Japanese)

- `nyaosorg/go-box` を v3.0.0 に更新し、API の変更に対応
- `nyaosorg/go-readline-ny` を v1.12.1 に更新
- 依存関係の更新を反映するため `go mod tidy` を実行
- 修正箇所に対して `go fmt` を実行