### PR TITLE
Rename release note files to `CHANGELOG.md` and `CHANGELOG_ja.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog (English)
 ===================
 
+- Rename release note files to CHANGELOG.md and CHANGELOG\_ja.md (#21)
+
 v0.22.4
 -------
 Feb 1, 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-Release notes (English)
-=======================
+Changelog (English)
+===================
 
 v0.22.4
 -------

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -1,5 +1,5 @@
-Release notes (Japanese)
-========================
+Changelog (Japanese)
+====================
 
 v0.22.4
 -------

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -1,6 +1,8 @@
 Changelog (Japanese)
 ====================
 
+- リリースノートのファイルを CHANGELOG.md , CHANGELOG\_ja.md へリネーム (#21)
+
 v0.22.4
 -------
 Feb 1, 2026

--- a/README.md
+++ b/README.md
@@ -222,11 +222,11 @@ func main() {
 ```
 
 
-Release notes
--------------
+Changelog
+---------
 
-- [Release notes (English)](./release_note_en.md)
-- [Release notes (Japanese)](./release_note_ja.md)
+- [Changelog (English)](./CHANGELOG.md)
+- [Changelog (Japanese)](./CHANGELOG_ja.md)
 
 Acknowledgements
 ----------------


### PR DESCRIPTION
(English)
- Rename release note files to `CHANGELOG.md` and `CHANGELOG_ja.md`

(Japanese)
- リリースノートのファイルを `CHANGELOG.md` , `CHANGELOG_ja.md` へリネーム