### PR TITLE
Fix newline marker rendering and add OnAfterRender example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,7 @@ demo:
 release:
 	pwsh tools/latest-notes.ps1 | gh release create -d --notes-file - -t $(VERSION) $(VERSION)
 
+readme:
+	$(GO) run github.com/hymkor/example-into-readme@latest
 
 .PHONY: all try test demo

--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ func main() {
         Candidates: getCompletionCandidates,
     })
 
+    // Show newline mark (experimental)
+    ed.OnAfterRender = func(w io.Writer, availWidth int) {
+        if availWidth >= 2 {
+            io.WriteString(w, "\x1B[33;22m↓\x1B[39m")
+        }
+    }
+
     for {
         lines, err := ed.Read(ctx)
         if err != nil {

--- a/examples/example.go
+++ b/examples/example.go
@@ -99,6 +99,13 @@ func main() {
 		Candidates: getCompletionCandidates,
 	})
 
+	// Show newline mark (experimental)
+	ed.OnAfterRender = func(w io.Writer, availWidth int) {
+		if availWidth >= 2 {
+			io.WriteString(w, "\x1B[33;22m↓\x1B[39m")
+		}
+	}
+
 	for {
 		lines, err := ed.Read(ctx)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -284,7 +284,7 @@ func (m *Editor) NewLine(_ context.Context, b *readline.Buffer) readline.Result 
 	b.RepaintAll()
 
 	m.after = func(line string) bool {
-		io.WriteString(m.LineEditor.Out, "\x1B[K\n")
+		io.WriteString(m.LineEditor.Out, "\n")
 		m.Sync(line)
 		m.LineEditor.Cursor = 0
 		m.csrline++


### PR DESCRIPTION
This PR improves the usability of the experimental `OnAfterRender` hook.

- Fix newline marker flicker caused by unnecessary line clearing
- examples/example.go : Add an example using `OnAfterRender`
- README.md: Update README to include the example
- Makefile: Add `make readme` target to automate embedding

These changes make it easier to understand and use `OnAfterRender` for custom rendering such as newline markers.

`OnAfterRender` についてフォローします。

- `OnAfterRender` で表示させた出力内容（いわゆる改行記号に使うことを想定）が、Enter を押下した直後だけ消えてしまう問題を修正
- examples/example.go: `OnAfterRender` を使った例を追加
- README.md: example.go からの引用を更新
- Makefile: example.go → README.md へ反映するためのエントリを追加